### PR TITLE
fix: c1 heightmap fix. opengl win fix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(CarnivoresRenderer)
 # Add .lib files
 link_directories(${CMAKE_SOURCE_DIR}/lib)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/runtime/config.json
+++ b/runtime/config.json
@@ -1,9 +1,9 @@
 {
-  "basePath": "../../runtime/cce/",
+  "basePath": "runtime\\cce\\",
   "map": {
     "type": "C1",
-    "map": "../game/c1/area2.map",
-    "rsc": "../game/c1/area2.rsc"
+    "map": "game\\c1\\area6.map",
+    "rsc": "game\\c1\\area6.rsc"
   },
   "video": {
     "fullscreen": false

--- a/src/C2MapFile.cpp
+++ b/src/C2MapFile.cpp
@@ -211,7 +211,15 @@ float C2MapFile::getHeightAt(int xy)
   if (m_type == CEMapType::C2) {
     scaled_height = this->m_heightmap_data.at(xy) * this->getHeightmapScale();
   } else {
-    scaled_height = this->m_watermap_data.at(xy) * this->getHeightmapScale();
+      auto c1WaterHeight = this->m_watermap_data.at(xy);
+      auto c1LandHeight = this->m_heightmap_data.at(xy);
+      uint8_t flags = this->getFlagsAt(xy);
+      if (flags & 0x80) {
+          scaled_height = (c1WaterHeight) * this->getHeightmapScale();
+      }
+      else {
+          scaled_height = (c1LandHeight + 48) * this->getHeightmapScale();
+      }
   }
 
   return (scaled_height);

--- a/src/C2Sky.cpp
+++ b/src/C2Sky.cpp
@@ -68,9 +68,8 @@ void C2Sky::loadTextureIntoMemory()
      GL_TEXTURE_CUBE_MAP_NEGATIVE_Z    Front
      */
 
-    // Use a common internal format and format/type combination
     for (int i = 0; i < 6; i++) {
-        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA, 256, 256, 0, GL_RGBA, GL_UNSIGNED_BYTE, this->m_texture->getRawData()->data());
+        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RED, 256, 256, 0, GL_RED, GL_UNSIGNED_BYTE, this->m_texture->getRawData()->data());
 
         GLenum error = glGetError();
         if (error != GL_NO_ERROR) {


### PR DESCRIPTION
Re:opengl.

Apparently this was resulting in a possible runtime issue in Windows (or certain drivers). The sky image is 256x256 BYTES. We mark it as such, but setting internal storage to RGB was causing (on some systems?) opengl to overread the data.

Setting to RED only avoids this. No notable affects so far? IDK.

Re heightmap, I think I finally got the logic right.