### PR TITLE
Tminard/ai first pass

### DIFF
--- a/runtime/config.json
+++ b/runtime/config.json
@@ -27,7 +27,22 @@
     {
       "file": "../../runtime/cce/game/models/velo2.car",
       "animation": "Vel_run1",
-      "position": [136, 261]
+      "position": [256, 256],
+      "attachAI": {
+        "controller": "GenericAmbient",
+        "args": {
+          "animations": {
+            "WALK": "Vel_wlk",
+            "RUN": "Vel_run1",
+            "DIE": "Vel_die1",
+            "SLEEP": "Vel_slp"
+          },
+          "character": {
+            "walkSpeed": 3,
+            "runSpeed": 6
+          }
+        }
+      }
     },
     {
       "file": "../../runtime/cce/game/models/velo2.car",

--- a/src/C2MapFile.cpp
+++ b/src/C2MapFile.cpp
@@ -450,6 +450,32 @@ glm::vec2 C2MapFile::getXYAtWorldPosition(glm::vec2 pos)
   return xy;
 }
 
+// Take tile x,y and return actual x,y,z marking the center of the tile
+// at world coordinates and at ground or water level
+glm::vec3 C2MapFile::getPositionAtCenterTile(glm::vec2 pos)
+{
+  int x = pos.x;
+  int y = pos.y;
+  
+  if (x < 0 || x > getWidth() || y < 0 || y > getHeight()) {
+    return glm::vec3(0.f);
+  }
+  
+  bool hasWater = hasWaterAt(x, y);
+  
+  float height = hasWater ? getWaterHeightAt(x, y) : getPlaceGroundHeight(x, y);
+  
+  float tile = getTileLength();
+  float halfTile = tile / 2.f;
+
+  return glm::vec3((static_cast<float>(x) * tile) + halfTile, height, (static_cast<float>(y) * tile) + halfTile);
+}
+
+glm::vec2 C2MapFile::getWorldTilePosition(glm::vec3 pos)
+{
+  return glm::vec2(int(floorf(pos.x / getTileLength())), int(floorf(pos.z / getTileLength())));
+}
+
 float C2MapFile::getAngleBetweenPoints(glm::vec3 a, glm::vec3 b)
 {
   glm::vec3 da=glm::normalize(a);

--- a/src/C2MapFile.h
+++ b/src/C2MapFile.h
@@ -82,6 +82,8 @@ public:
   uint16_t getFlagsAt(int x, int y);
 
   glm::vec2 getXYAtWorldPosition(glm::vec2 pos);
+  glm::vec3 getPositionAtCenterTile(glm::vec2 pos);
+  glm::vec2 getWorldTilePosition(glm::vec3 pos);
   
   glm::vec3 getRandomLanding();
 

--- a/src/CEAIGenericAmbientManager.cpp
+++ b/src/CEAIGenericAmbientManager.cpp
@@ -1,0 +1,115 @@
+#include "CEAIGenericAmbientManager.hpp"
+
+#include "CERemotePlayerController.hpp"
+#include "C2MapFile.h"
+#include "C2MapRscFile.h"
+
+#include <random>
+#include <cmath>
+#include <iostream>
+
+CEAIGenericAmbientManager::CEAIGenericAmbientManager(AIGenericAmbientManagerConfig config, std::shared_ptr<CERemotePlayerController> playerController, std::shared_ptr<C2MapFile> map, std::shared_ptr<C2MapRscFile> rsc): m_config(config), m_player_controller(playerController), m_map(map), m_rsc(rsc)
+{
+  m_last_process_time = 0;
+  m_target_expire_time = 0;
+  m_current_target = glm::vec3(-1.f);
+}
+
+const float move_distance = 164.f; // Movement per delta time
+// TODO: only allow movement in direction we are facing
+const std::vector<glm::vec2> directions = {
+    {1, 0},   // Right
+    {1, 1},   // Up-right
+    {0, 1},   // Up
+    {-1, 1},  // Up-left
+    {-1, 0},  // Left
+    {-1, -1}, // Down-left
+    {0, -1},  // Down
+    {1, -1}   // Down-right
+};
+
+bool CEAIGenericAmbientManager::isTilePassable(glm::vec2 tile)
+{
+  glm::vec3 actualPos = m_map->getPositionAtCenterTile(tile);
+  glm::vec3 curPos = m_player_controller->getPosition();
+  // check if movement here is allowed
+  if (abs((actualPos.y - curPos.y)) < 128.f) {
+    return true;
+  }
+  
+  // TODO: check for water
+  
+  return false;
+}
+
+void CEAIGenericAmbientManager::Process(double currentTime)
+{
+  double delta = currentTime - m_last_process_time;
+  glm::vec3 currentPosition = m_player_controller->getPosition();
+  
+  float distToTarget = glm::distance(currentPosition, m_current_target);
+  
+  // Determine target
+  bool curTargetExpired = m_target_expire_time < currentTime;
+  // TODO: deal with getting stuck
+  bool needNewTarget = curTargetExpired || m_current_target.x < 0.f || distToTarget < 128.f;
+  if (needNewTarget) {
+    float range = (m_map->getTileLength() * 12.f);
+    std::random_device rd; // Seed
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+    std::uniform_real_distribution<float> dist(-range, range);
+
+    // Pick a random x and y position within n tiles in either direction
+    float randomOffsetX = dist(gen);
+    float randomOffsetY = dist(gen);
+    
+    m_current_target.x = currentPosition.x + randomOffsetX;
+    m_current_target.y = currentPosition.z;
+    m_current_target.z = currentPosition.y + randomOffsetY;
+    
+    m_target_expire_time = currentTime + 30;
+  }
+  
+  // Move toward target, avoiding blockers and impassable terrain
+  // Find best direction to move towards the target
+  float bestValue = -std::numeric_limits<float>::max();
+  glm::vec3 bestDirection = currentPosition;
+
+  for (const glm::vec2& dir : directions) {
+      glm::vec3 potentialPosition = currentPosition + glm::vec3(dir.x, 0, dir.y) * move_distance * static_cast<float>(delta);
+      // get tile at that position
+      glm::vec2 potentialPositionTile = m_map->getWorldTilePosition(potentialPosition);
+
+      // Check if the potential position is passable
+      bool isPassable = isTilePassable(potentialPositionTile);
+      
+      // Calculate the distance to the target from the potential position
+      float potentialDistToTarget = glm::distance(potentialPosition, m_current_target);
+
+      // Determine a value that represents how good this direction is
+      float value = -potentialDistToTarget; // Closer to target is better, so use negative distance
+
+      // If the position is passable and has a better value, select it
+      if (isPassable && value > bestValue) {
+          bestValue = value;
+          bestDirection = potentialPosition;
+      }
+  }
+  
+  // Make sure we are looking in the direction we are walking
+  // If not, we need to rotate (via slide animation?) for N frames until we are,
+  // or move in our forward direction while altering our rotation each frame
+
+  // Move towards the best direction found
+  if (bestValue != -std::numeric_limits<float>::max()) {
+    // TODO: call move and delete all movement time processing from this class!
+      bestDirection.y = m_map->getPositionAtCenterTile(m_player_controller->getWorldPosition()).y;
+    m_player_controller->lookAt(bestDirection);
+    m_player_controller->setPosition(bestDirection);
+  }
+    
+  // Update animation state if needed
+  m_player_controller->setNextAnimation(m_config.WalkAnimName);
+  
+  m_last_process_time = currentTime;
+}

--- a/src/CEAIGenericAmbientManager.hpp
+++ b/src/CEAIGenericAmbientManager.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stdio.h>
+#include <memory>
+#include <string>
+#include <glm/glm.hpp>
+
+class CERemotePlayerController;
+class C2MapFile;
+class C2MapRscFile;
+
+struct AIGenericAmbientManagerConfig {
+  std::string WalkAnimName;
+};
+
+class CEAIGenericAmbientManager {
+  std::shared_ptr<CERemotePlayerController> m_player_controller;
+  std::shared_ptr<C2MapFile> m_map;
+  std::shared_ptr<C2MapRscFile> m_rsc;
+  AIGenericAmbientManagerConfig m_config;
+  
+  double m_last_process_time;
+  double m_target_expire_time;
+  
+  glm::vec3 m_current_target;
+  
+  bool isTilePassable(glm::vec2 tile);
+public:
+  CEAIGenericAmbientManager(AIGenericAmbientManagerConfig config, std::shared_ptr<CERemotePlayerController> playerController, std::shared_ptr<C2MapFile> map, std::shared_ptr<C2MapRscFile> rsc);
+  
+  void Process(double currentTime);
+};

--- a/src/CEAudioSource.cpp
+++ b/src/CEAudioSource.cpp
@@ -43,9 +43,10 @@ void CEAudioSource::upload()
     alSource3f(m_audio_source, AL_POSITION, 0, 0, 0);
     alSource3f(m_audio_source, AL_VELOCITY, 0, 0, 0);
 
-    alSourcei(m_audio_source, AL_ROLLOFF_FACTOR, 1); // decline in gain starting at ref distance, through max distance
-    alSourcei(m_audio_source, AL_MAX_DISTANCE, (256*100*2)); // distance until gain is 0
-    alSourcei(m_audio_source, AL_REFERENCE_DISTANCE, (256*1*2)); // clamped distance; up to distance where gain is always 1
+    alSourcef(m_audio_source, AL_ROLLOFF_FACTOR, 256.f); // decline in gain starting at ref distance, through max distance
+    alSourcei(m_audio_source, AL_MAX_DISTANCE, 256*60); // distance until gain is 0
+  
+    alSourcei(m_audio_source, AL_REFERENCE_DISTANCE, (256*1)); // clamped distance; up to distance where gain is always 1
 
     alGenBuffers(1, &m_audio_buffer);
 

--- a/src/CERemotePlayerController.cpp
+++ b/src/CERemotePlayerController.cpp
@@ -98,8 +98,8 @@ void CERemotePlayerController::update(double currentTime, Transform &baseTransfo
       if (audioSrc) {
         audioSrc->setPosition(m_camera.GetCurrentPos());
         audioSrc->setLooped(false);
-        audioSrc->setMaxDistance(m_map->getTileLength() * 60.f);
-        audioSrc->setClampDistance(6);
+        // TODO: allow character to control audio distance
+        audioSrc->setMaxDistance(m_map->getTileLength() * 45.f);
         m_g_audio_manager->play(audioSrc);
       }
     }

--- a/src/CERemotePlayerController.hpp
+++ b/src/CERemotePlayerController.hpp
@@ -45,6 +45,7 @@ private:
   std::unique_ptr<CEGeometry> m_geo;
   
   std::string m_current_animation;
+  glm::vec3 m_look_at;
   // Currently always 0, but eventually marks the start of an ani
   double m_animation_started_at;
   
@@ -79,6 +80,8 @@ public:
   void setPosition(glm::vec3 position);
   void setElevation(float elevation);
   void lookAt(glm::vec3 direction);
+  
+  void setNextAnimation(std::string animationName);
 
   void update(double currentTime, Transform &baseTransform, Camera &observerCamera, glm::vec2 observerWorldPosition);
   

--- a/src/LocalAudioManager.cpp
+++ b/src/LocalAudioManager.cpp
@@ -116,6 +116,9 @@ void LocalAudioManager::setupDevice()
   if (!this->m_alc_context) {
       throw std::runtime_error("Could not create audio context. FATAL.");
   }
+  
+  alDistanceModel(AL_INVERSE_DISTANCE_CLAMPED);
+  checkError();
 
   if (!alcMakeContextCurrent(m_alc_context)) {
       checkError();


### PR DESCRIPTION
Still a prototype just while I figure out how I want to implement this.

General idea is that there can be multiple AI controllers. Initial one is "GenericAmbient", but others could be "FlyableAmbient", "UnderwaterAmbient", etc.

Input parameters (e.g., mappings to specific animations) can be provided in a json config.

A AI manager class controls a `CERemotePlayerController`. The player control itself is responsible for actually applying movement. The AI manager class simply informs the controller what to do.

This kind of setup will allow me to implement a network manager type in the future that can both host and receive remote status packets and pass those down to specific RemotePlayerControllers. This approach will make the engine network-first.